### PR TITLE
bugfix 为OutBoundChannelGroup设置了获取连接超时时间，值为心跳间隔的一半

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ hs_err_pid*
 /xraft.iml
 /.idea
 /xraft-kvstore/xraft-kvstore.iml
+/xraft-core/xraft-core.iml
+xraft-parent.iml
+/xraft-parent.iml

--- a/xraft-core/src/main/java/in/xnnyygn/xraft/core/node/NodeBuilder.java
+++ b/xraft-core/src/main/java/in/xnnyygn/xraft/core/node/NodeBuilder.java
@@ -283,9 +283,10 @@ public class NodeBuilder {
     private NioConnector createNioConnector() {
         int port = group.findSelf().getEndpoint().getPort();
         if (workerNioEventLoopGroup != null) {
-            return new NioConnector(workerNioEventLoopGroup, selfId, eventBus, port);
+            return new NioConnector(workerNioEventLoopGroup, selfId, eventBus, port, config.getLogReplicationInterval());
         }
-        return new NioConnector(new NioEventLoopGroup(config.getNioWorkerThreads()), false, selfId, eventBus, port);
+        return new NioConnector(new NioEventLoopGroup(config.getNioWorkerThreads()), false,
+                selfId, eventBus, port, config.getLogReplicationInterval());
     }
 
     /**

--- a/xraft-core/src/main/java/in/xnnyygn/xraft/core/rpc/nio/NioConnector.java
+++ b/xraft-core/src/main/java/in/xnnyygn/xraft/core/rpc/nio/NioConnector.java
@@ -20,6 +20,8 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 // TODO add test
 @ThreadSafe
@@ -33,6 +35,13 @@ public class NioConnector implements Connector {
     private final int port;
     private final InboundChannelGroup inboundChannelGroup = new InboundChannelGroup();
     private final OutboundChannelGroup outboundChannelGroup;
+    private final ExecutorService executorService = Executors.newCachedThreadPool((r) -> {
+        Thread thread = new Thread(r);
+        thread.setUncaughtExceptionHandler((t, e) -> {
+            logException(e);
+        });
+        return thread;
+    });
 
     public NioConnector(NodeId selfNodeId, EventBus eventBus, int port, int logReplicationInterval) {
         this(new NioEventLoopGroup(), false, selfNodeId, eventBus, port, logReplicationInterval);
@@ -81,15 +90,11 @@ public class NioConnector implements Connector {
         Preconditions.checkNotNull(destinationEndpoints);
         for (NodeEndpoint endpoint : destinationEndpoints) {
             logger.debug("send {} to node {}", rpc, endpoint.getId());
-            try {
-                getChannel(endpoint).writeRequestVoteRpc(rpc);
-            } catch (Exception e) {
-                logException(e);
-            }
+            executorService.execute(() -> getChannel(endpoint).writeRequestVoteRpc(rpc));
         }
     }
 
-    private void logException(Exception e) {
+    private void logException(Throwable e) {
         if (e instanceof ChannelConnectException) {
             logger.warn(e.getMessage());
         } else {
@@ -114,11 +119,7 @@ public class NioConnector implements Connector {
         Preconditions.checkNotNull(rpc);
         Preconditions.checkNotNull(destinationEndpoint);
         logger.debug("send {} to node {}", rpc, destinationEndpoint.getId());
-        try {
-            getChannel(destinationEndpoint).writeAppendEntriesRpc(rpc);
-        } catch (Exception e) {
-            logException(e);
-        }
+        executorService.execute(() -> getChannel(destinationEndpoint).writeAppendEntriesRpc(rpc));
     }
 
     @Override

--- a/xraft-core/src/main/java/in/xnnyygn/xraft/core/rpc/nio/NioConnector.java
+++ b/xraft-core/src/main/java/in/xnnyygn/xraft/core/rpc/nio/NioConnector.java
@@ -34,20 +34,22 @@ public class NioConnector implements Connector {
     private final InboundChannelGroup inboundChannelGroup = new InboundChannelGroup();
     private final OutboundChannelGroup outboundChannelGroup;
 
-    public NioConnector(NodeId selfNodeId, EventBus eventBus, int port) {
-        this(new NioEventLoopGroup(), false, selfNodeId, eventBus, port);
+    public NioConnector(NodeId selfNodeId, EventBus eventBus, int port, int logReplicationInterval) {
+        this(new NioEventLoopGroup(), false, selfNodeId, eventBus, port, logReplicationInterval);
     }
 
-    public NioConnector(NioEventLoopGroup workerNioEventLoopGroup, NodeId selfNodeId, EventBus eventBus, int port) {
-        this(workerNioEventLoopGroup, true, selfNodeId, eventBus, port);
+    public NioConnector(NioEventLoopGroup workerNioEventLoopGroup, NodeId selfNodeId, EventBus eventBus, int port, int logReplicationInterval) {
+        this(workerNioEventLoopGroup, true, selfNodeId, eventBus, port, logReplicationInterval);
     }
 
-    public NioConnector(NioEventLoopGroup workerNioEventLoopGroup, boolean workerGroupShared, NodeId selfNodeId, EventBus eventBus, int port) {
+    public NioConnector(NioEventLoopGroup workerNioEventLoopGroup, boolean workerGroupShared,
+                        NodeId selfNodeId, EventBus eventBus,
+                        int port, int logReplicationInterval) {
         this.workerNioEventLoopGroup = workerNioEventLoopGroup;
         this.workerGroupShared = workerGroupShared;
         this.eventBus = eventBus;
         this.port = port;
-        outboundChannelGroup = new OutboundChannelGroup(workerNioEventLoopGroup, eventBus, selfNodeId);
+        outboundChannelGroup = new OutboundChannelGroup(workerNioEventLoopGroup, eventBus, selfNodeId, logReplicationInterval);
     }
 
     // should not call more than once

--- a/xraft-core/src/main/java/in/xnnyygn/xraft/core/rpc/nio/OutboundChannelGroup.java
+++ b/xraft-core/src/main/java/in/xnnyygn/xraft/core/rpc/nio/OutboundChannelGroup.java
@@ -23,12 +23,14 @@ class OutboundChannelGroup {
     private final EventLoopGroup workerGroup;
     private final EventBus eventBus;
     private final NodeId selfNodeId;
+    private final int connectTimeoutMillis;
     private final ConcurrentMap<NodeId, Future<NioChannel>> channelMap = new ConcurrentHashMap<>();
 
-    OutboundChannelGroup(EventLoopGroup workerGroup, EventBus eventBus, NodeId selfNodeId) {
+    OutboundChannelGroup(EventLoopGroup workerGroup, EventBus eventBus, NodeId selfNodeId, int logReplicationInterval) {
         this.workerGroup = workerGroup;
         this.eventBus = eventBus;
         this.selfNodeId = selfNodeId;
+        this.connectTimeoutMillis = logReplicationInterval / 2;
     }
 
     NioChannel getOrConnect(NodeId nodeId, Address address) {
@@ -61,6 +63,7 @@ class OutboundChannelGroup {
                 .group(workerGroup)
                 .channel(NioSocketChannel.class)
                 .option(ChannelOption.TCP_NODELAY, true)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMillis)
                 .handler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     protected void initChannel(SocketChannel ch) throws Exception {


### PR DESCRIPTION
之前都是三节点测试，该修改在三节点测试中通过，但是突然想到了发起连接似乎被写成了串行化操作（同一时间只对一台服务器发起连接）而非并行化（同时对多台服务器发起连接），这会导致在集群中拥有更多节点时，超时时间叠加后超过心跳间隔，于是测试了11节点的情况，果然存在这个问题：6节点在线5节点下线导致超时时间叠加到了2.5秒，超过了心跳间隔。
会在下一次PR中修复这个问题。

之所以close上一次PR是因为在后来的测试中客户端的端口号错填了core的端口（而不是kv服务的端口），导致我以为出问题了（其实并没有）。