### PR TITLE
fix #33 ignore request vote result with lower term

### DIFF
--- a/xraft-core/src/main/java/in/xnnyygn/xraft/core/node/NodeImpl.java
+++ b/xraft-core/src/main/java/in/xnnyygn/xraft/core/node/NodeImpl.java
@@ -617,7 +617,11 @@ public class NodeImpl implements Node {
         if (result.getTerm() > role.getTerm()) {
             becomeFollower(result.getTerm(), null, null, 0, true);
             return;
-        }
+        } else if (result.getTerm() < role.getTerm()) {
+            // ignore stale term
+            logger.debug("receive request vote result and result term is smaller, ignore");
+            return;
+         }
 
         // check role
         if (role.getName() != RoleName.CANDIDATE) {


### PR DESCRIPTION
Hi there!

I recently noticed the bug (#33) also exists in the develop branch. This bug can also be reproduced as the Raft protocol requires the term check before processing RequestVote. Therefore, I am creating this PR to fix the issue in case people want to learn from the PreVote extension but aren't familiar with the differences between the develop and master branches.

Please let me know if you have any questions or feedback on this fix. Thank you for your time!