### PR TITLE
fix #40: copy entries.subList in MemoryEntrySequence to prevent ConcurrentModificationException

### DIFF
--- a/xraft-core/src/main/java/in/xnnyygn/xraft/core/log/sequence/MemoryEntrySequence.java
+++ b/xraft-core/src/main/java/in/xnnyygn/xraft/core/log/sequence/MemoryEntrySequence.java
@@ -22,7 +22,7 @@ public class MemoryEntrySequence extends AbstractEntrySequence {
 
     @Override
     protected List<Entry> doSubList(int fromIndex, int toIndex) {
-        return entries.subList(fromIndex - logIndexOffset, toIndex - logIndexOffset);
+        return new ArrayList<>(entries.subList(fromIndex - logIndexOffset, toIndex - logIndexOffset));
     }
 
     @Override


### PR DESCRIPTION
Fix #40

Thank you for your quick response! I have tested the fix, and no exceptions are raised now.